### PR TITLE
Allow Rails 7.1 versions in gemspec

### DIFF
--- a/devise-two-factor.gemspec
+++ b/devise-two-factor.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- spec/*`.split("\n")
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'railties',       '< 7.1'
-  s.add_runtime_dependency 'activesupport',  '< 7.1'
+  s.add_runtime_dependency 'railties',       '< 7.2'
+  s.add_runtime_dependency 'activesupport',  '< 7.2'
   s.add_runtime_dependency 'attr_encrypted', '>= 1.3', '< 5', '!= 2'
   s.add_runtime_dependency 'devise',         '~> 4.0'
   s.add_runtime_dependency 'rotp',           '~> 6.0'


### PR DESCRIPTION
Fixes https://github.com/devise-two-factor/devise-two-factor/issues/253

