### PR TITLE
Update changelog to have accurate title for diff from 4.0.1 to 4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Rails 7 is now required.
 
 
-## 4.0.2
+## 4.1.0
 - Add Rails 7.0 support
 - Renew signing certificate
 - Use `after` option of TOTP#verify for additional timestamp verification


### PR DESCRIPTION
This was confusing for my work PR around updating `attr_encrypted` which forced an upgrade of `devise-two-factor` so I want to make a PR about it - feel free to close if this is wrong. According to https://github.com/devise-two-factor/devise-two-factor/compare/v4.0.2...v4.1.0 it looks like this changelog section is for `4.1.0` which includes the `attr_encrypted` update

https://rubygems.org/gems/devise-two-factor/versions says:
```
[5.0.0](https://rubygems.org/gems/devise-two-factor/versions/5.0.0) - July 11, 2022 (32 KB)
[4.1.1](https://rubygems.org/gems/devise-two-factor/versions/4.1.1) - October 12, 2023 (29.5 KB)
[4.1.0](https://rubygems.org/gems/devise-two-factor/versions/4.1.0) - May 05, 2023 (29.5 KB)
[4.0.2](https://rubygems.org/gems/devise-two-factor/versions/4.0.2) - March 24, 2022 (29.5 KB)
```

I am not sure what is in the `4.1.1` gem version so I did not add a new section for it here