### PR TITLE
link to old readme on the upgrading from 4x to 5x guide

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -59,7 +59,7 @@ This gem must be upgraded **as part of a Rails 7 upgrade**. See [the official Ra
     ```
 1. Add a `legacy_otp_secret` method to your user model e.g. `User`.
   * This method is used by the gem to find and decode the OTP secret from the legacy database columns.
-  * The implementation shown below works if you set up devise-two-factor with the settings suggested in the [README](./README.md).
+  * The implementation shown below works if you set up devise-two-factor with the settings suggested in the [OLD README](https://github.com/devise-two-factor/devise-two-factor/blob/8d74f5ee45594bf00e60d5d49eb6fcde82c2d2ba/README.md).
   * If you have customised the encryption scheme used to store the OTP secret then you will need to update this method to match.
   * If you are unsure, you should try the method below as is, and if you can still sign in users with OTP enabled then all is well.
     ```ruby


### PR DESCRIPTION
On the upgrading from 4x to 5x guide, the _readme_ link should probably point to the old _readme_ file. 

### Implementation

I grabbed the _readme_ that existed right before the commit that changed it to the current one.

[See the commit where the changes were made](https://github.com/devise-two-factor/devise-two-factor/commit/f2e9b4b79d73dbda19276afd4e15326d210d6ad3).

[See the readme file I linked to](https://github.com/devise-two-factor/devise-two-factor/blob/8d74f5ee45594bf00e60d5d49eb6fcde82c2d2ba/README.md).

### Motivation

I was following the guide. In order to see if my project had the old suggested setup, it would have been easier to see the old _readme_ version with the old setup.