### PR TITLE
add missing clean up step on the upgrading guide

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -190,6 +190,15 @@ This "clean up" phase can happen at the same time as your initial deployment but
       end
     end
     ```
+4. Remove `otp_secret_encryption_key` from the model setup. This also assumes you successfully ran the rake task in step 1.
+    ```ruby
+    # from this:
+    devise :two_factor_authenticatable,
+        otp_secret_encryption_key: ENV['YOUR_ENCRYPTION_KEY_HERE']
+
+    # to this:
+    devise :two_factor_authenticatable
+    ```
 
 # Guide to upgrading from 2.x to 3.x
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -190,7 +190,7 @@ This "clean up" phase can happen at the same time as your initial deployment but
       end
     end
     ```
-4. Remove `otp_secret_encryption_key` from the model setup. This also assumes you successfully ran the rake task in step 1.
+1. Remove `otp_secret_encryption_key` from the model setup. This also assumes you successfully ran the rake task in step 1.
     ```ruby
     # from this:
     devise :two_factor_authenticatable,


### PR DESCRIPTION
Closes https://github.com/devise-two-factor/devise-two-factor/issues/242

#### Motivation

When migrating from 4.x to 5.x, assuming you ran rake tasks to migrate the legacy format to the new one, you don´t need the `otp_secret_encryption_key: ENV['YOUR_ENCRYPTION_KEY_HERE']` anymore. 