### PR TITLE
Add Instruction of backup code for MySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,23 @@ class AddDeviseTwoFactorBackupableToUsers < ActiveRecord::Migration
 end
 ```
 
+If you're using Rails >= 6.1 with MySQL, you can handle backup codes as follows:
+
+```ruby
+# migration
+class AddDeviseTwoFactorBackupableToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :otp_backup_codes, :text
+  end
+end
+
+# model
+class User < ApplicationRecord
+  devise :two_factor_backupable
+  serialize :otp_backup_codes, Array
+end
+```
+
 You can then generate backup codes for a user:
 
 ```ruby


### PR DESCRIPTION
The current README does not support handling backup codes with MySQL, as the `array: true` option in migrations is not valid for MySQL.

I have placed code that demonstrates this in the repository at https://github.com/skuroki/test_devise_two_factor, so please check it if necessary.

Instead, in the current version of Rails(>= 6.1), you can handle backup codes by using the serialize declaration. I would like to propose adding this information to the README so that others do not struggle with the same issue.