### PR TITLE
fix: backup codes are not invalidated

### DIFF
--- a/lib/devise_two_factor/models/two_factor_backupable.rb
+++ b/lib/devise_two_factor/models/two_factor_backupable.rb
@@ -39,6 +39,7 @@ module Devise
 
           codes.delete(backup_code)
           self.otp_backup_codes = codes
+          self.save(validate: false) # prevent backup code re-use
           return true
         end
 


### PR DESCRIPTION
`invalidate_otp_backup_code!` does not persist the user in the same way `validate_and_consume_otp!` does

- persist the codes (without the invalidated one)
- the method has a `!` so I assumed it did this anyway