### PR TITLE
Update documentation for otp_provisioning_uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,7 @@ At Tinfoil Security, we opted to use the excellent [rqrcode-rails3](https://gith
 If you decide to do this you'll need to generate a URI to act as the source for the QR code. This can be done using the `User#otp_provisioning_uri` method.
 
 ```ruby
-issuer = 'Your App'
-label = "#{issuer}:#{current_user.email}"
-
-current_user.otp_provisioning_uri(label, issuer: issuer)
+current_user.otp_provisioning_uri(current_user.email, issuer: 'Your App')
 
 # > "otpauth://totp/Your%20App:user@example.com?secret=[otp_secret]&issuer=Your+App"
 ```


### PR DESCRIPTION
devise-two-factor 6.1.0

The current example in the README for `otp_provisioning_uri` results in the issuer being repeated in the path part of the returned String.

```
> issuer = 'Your App'
=> "Your App"
> label = "#{issuer}:#{user.email}"
=> "Your App:user@example.com"
> user.otp_provisioning_uri(label, issuer: issuer)
=> "otpauth://totp/Your%20App:Your%20App_user%40example.com?secret=[otp_secret]&issuer=Your%20App"
```
While the documentation indicates the return would be
```
=> "otpauth://totp/Your%20App:user@example.com?secret=[otp_secret]&issuer=Your+App"
```
Assuming the documentation's return value is what is desired, update the example in the README.

This touches on part of #190.