### PR TITLE
Graceful check for params and otp_attempt in two_factor_backupable.rb

### DIFF
--- a/lib/devise_two_factor/strategies/two_factor_backupable.rb
+++ b/lib/devise_two_factor/strategies/two_factor_backupable.rb
@@ -16,7 +16,7 @@ module Devise
         @halted = false if @result == :failure
       end
 
-      def validate_backup_code
+      def validate_backup_code(resource)
         return if params[scope].nil? || params[scope]['otp_attempt'].nil?
         resource.invalidate_otp_backup_code!(params[scope]['otp_attempt'])
       end

--- a/lib/devise_two_factor/strategies/two_factor_backupable.rb
+++ b/lib/devise_two_factor/strategies/two_factor_backupable.rb
@@ -5,7 +5,7 @@ module Devise
       def authenticate!
         resource = mapping.to.find_for_database_authentication(authentication_hash)
 
-        if validate(resource) { resource.invalidate_otp_backup_code!(params[scope]['otp_attempt']) }
+        if validate(resource) { validate_backup_code(resource) }
           super
         end
 
@@ -14,6 +14,11 @@ module Devise
         # We want to cascade to the next strategy if this one fails,
         # but database authenticatable automatically halts on a bad password
         @halted = false if @result == :failure
+      end
+
+      def validate_backup_code
+        return if params[scope].nil? || params[scope]['otp_attempt'].nil?
+        resource.invalidate_otp_backup_code!(params[scope]['otp_attempt'])
       end
     end
   end


### PR DESCRIPTION
When params do not include the required scope key (e.g. user)
then TwoFactorBackupable throws exception "undefined method :[] for nil:NilClass".
This change is to handle such a scenario gracefully.