### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
         exclude:
           - ruby: '3.1'
             rails: '8.0'
+          - ruby: '3.4'
+            rails: '7.0'
 
     name: Ruby ${{ matrix.ruby }}, Rails ${{ matrix.rails }}
     env: # $BUNDLE_GEMFILE must be set at the job level, so it is set for all steps

--- a/lib/devise-two-factor.rb
+++ b/lib/devise-two-factor.rb
@@ -1,3 +1,4 @@
+require 'logger'
 require 'devise'
 require 'devise_two_factor/models'
 require 'devise_two_factor/strategies'


### PR DESCRIPTION
Rails 7.0 and Ruby 3.4 don't seem to be compatible directly in our CI. Logger needs to be required before loading devise to make sure the right constant is loaded.