### PR TITLE
Deal with databases that cannot correctly deserialize

### DIFF
--- a/lib/devise_two_factor/models/two_factor_backupable.rb
+++ b/lib/devise_two_factor/models/two_factor_backupable.rb
@@ -34,6 +34,15 @@ module Devise
       def invalidate_otp_backup_code!(code)
         codes = self.otp_backup_codes || []
 
+        # Cooerce from serialized string to array; should the database not support array serialization properly.
+        codes = JSON.parse(codes) if codes.is_a?(String)
+
+        # Should we still have some other kind of non iterable result, terminate.
+        unless codes.is_a?(Array)
+          # TODO: Is there a reliable Rails.logger.warn or Kernel.warn that can be safely logged here?
+          return false
+        end
+
         codes.each do |backup_code|
           next unless Devise::Encryptor.compare(self.class, backup_code, code)
 

--- a/lib/devise_two_factor/models/two_factor_backupable.rb
+++ b/lib/devise_two_factor/models/two_factor_backupable.rb
@@ -35,7 +35,11 @@ module Devise
         codes = self.otp_backup_codes || []
 
         # Cooerce from serialized string to array; should the database not support array serialization properly.
-        codes = JSON.parse(codes) if codes.is_a?(String)
+        if codes.is_a?(String)
+          # TODO: Is there a reliable Rails.logger.warn or similar that can point out the database serialization is not
+          #       as expected.
+          codes = JSON.parse(codes)
+        end
 
         # Should we still have some other kind of non iterable result, terminate.
         unless codes.is_a?(Array)

--- a/lib/devise_two_factor/spec_helpers/two_factor_backupable_shared_examples.rb
+++ b/lib/devise_two_factor/spec_helpers/two_factor_backupable_shared_examples.rb
@@ -98,10 +98,11 @@ RSpec.shared_examples 'two_factor_backupable' do
 
       context "with backup codes as a string" do
         before do
+          @plaintext_codes = subject.generate_otp_backup_codes!
+
           # Simulates database adapters that don't understand `t.string :otp_backup_codes, type: array` properly
           # such as SQL Server; and have just returned the serialized string still.
-          @plaintext_codes = subject.generate_otp_backup_codes!
-          subject.otp_backup_codes = @plaintext_codes.to_json
+          subject.otp_backup_codes = subject.otp_backup_codes.to_json
         end
 
         context 'given an invalid recovery code' do


### PR DESCRIPTION
Fix https://github.com/devise-two-factor/devise-two-factor/issues/302 ?

- [ ] Security considerations - I think its safe-ish to JSON.parse, but its kind of a kludgey workaround for the various activerecord adapters not properly deserializing this
- [ ] Is it better to raise a meaningful exception to make sure people `serialize :otp_backup_codes, Array` in the model?